### PR TITLE
Allow section to be defined by custom configy environment variable

### DIFF
--- a/lib/configy.rb
+++ b/lib/configy.rb
@@ -26,6 +26,8 @@ module Configy
     def section
       if @section
         @section
+      elsif defined? CONFIGY_ENV
+        CONFIGY_ENV
       elsif defined? Rails
         Rails.env
       elsif defined? RAILS_ENV

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -9,10 +9,16 @@ describe "Configy.section" do
     Configy.section.must_equal "development"
   end
 
+  it "should detect configy environment" do
+    with_const( :CONFIGY_ENV, "staging" ) do
+      Configy.section.must_equal "staging"
+    end
+  end
+
   it "should detect rails 3 environment" do
     rails3_obj = MiniTest::Mock.new
     rails3_obj.expect :env, "staging"
-  
+
     with_const(:Rails, rails3_obj) do
       Configy.section.must_equal "staging"
     end


### PR DESCRIPTION
I wanted to be able to specify the configy section via a custom environment variable in the case that we might have two servers that are considered "production", but one needs a different set of configs. Whaddya think?
